### PR TITLE
vimc-3319: Add additional environment variables to orderly

### DIFF
--- a/config/production.yml
+++ b/config/production.yml
@@ -9,6 +9,8 @@ orderly:
   ## Typically these will be in SHOUTY_SNAKE_CASE.  To pull values
   ## from the vault, use the format VAULT:<path>:<key>
   env:
+    MONTAGU_DB_DEFAULT_INSTANCE: production
+    MONTAGU_DB_PASSWORD_PRODUCTION: VAULT:secret/database/production/users/orderly:password
     MONTAGU_PASSWORD: VAULT:secret/database/production/users/orderly:password
     ORDERLY_API_SERVER_IDENTITY: production
     ANNEX_HOST: annex.montagu.dide.ic.ac.uk

--- a/config/science.yml
+++ b/config/science.yml
@@ -11,6 +11,8 @@ orderly:
   ## Typically these will be in SHOUTY_SNAKE_CASE.  To pull values
   ## from the vault, use the format VAULT:<path>:<key>
   env:
+    MONTAGU_DB_DEFAULT_INSTANCE: science
+    MONTAGU_DB_PASSWORD_SCIENCE: VAULT:secret/database/science/users/orderly:password
     MONTAGU_PASSWORD: VAULT:secret/database/science/users/orderly:password
     ORDERLY_API_SERVER_IDENTITY: science
     ANNEX_HOST: annex.montagu.dide.ic.ac.uk

--- a/config/uat.yml
+++ b/config/uat.yml
@@ -11,6 +11,8 @@ orderly:
   ## Typically these will be in SHOUTY_SNAKE_CASE.  To pull values
   ## from the vault, use the format VAULT:<path>:<key>
   env:
+    MONTAGU_DB_DEFAULT_INSTANCE: uat
+    MONTAGU_DB_PASSWORD_UAT: readonly
     MONTAGU_PASSWORD: orderly
     ORDERLY_API_SERVER_IDENTITY: uat
     ANNEX_HOST: db_annex


### PR DESCRIPTION
This PR introduces new environment variables that we need to support changes to the orderly database configuration.  They are harmless and have no effect in the current configuration, but will be used by [VIMC-3302](https://mrc-ide.myjetbrains.com/youtrack/issue/VIMC-3302) and [VIMC-3318](https://mrc-ide.myjetbrains.com/youtrack/issue/VIMC-3318)