### PR TITLE
vimc-3464: Configuration now uses the readonly user

### DIFF
--- a/config/latest.yml
+++ b/config/latest.yml
@@ -11,8 +11,9 @@ orderly:
   ## Typically these will be in SHOUTY_SNAKE_CASE.  To pull values
   ## from the vault, use the format VAULT:<path>:<key>
   env:
-    MONTAGU_PASSWORD: VAULT:secret/database/science/users/orderly:password
-    ORDERLY_API_SERVER_IDENTITY: science
+    MONTAGU_DB_DEFAULT_INSTANCE: latest
+    MONTAGU_DB_PASSWORD_SCIENCE: VAULT:secret/database/science/users/readonly:password
+    ORDERLY_API_SERVER_IDENTITY: latest
     ANNEX_HOST: annex.montagu.dide.ic.ac.uk
     ANNEX_PORT: 15432
     ANNEX_PASSWORD: VAULT:secret/annex/users/readonly:password

--- a/config/orderly-web.yml
+++ b/config/orderly-web.yml
@@ -57,9 +57,6 @@ orderly:
     tag: master
   env:
     SLACK_URL: VAULT:secret/slack/orderly-webhook:url
-    MONTAGU_USER: orderly
-    MONTAGU_HOST: db
-    MONTAGU_PORT: 5432
   ssh:
     public: VAULT:secret/reports/deploy:public
     private: VAULT:secret/reports/deploy:private

--- a/config/production.yml
+++ b/config/production.yml
@@ -10,8 +10,7 @@ orderly:
   ## from the vault, use the format VAULT:<path>:<key>
   env:
     MONTAGU_DB_DEFAULT_INSTANCE: production
-    MONTAGU_DB_PASSWORD_PRODUCTION: VAULT:secret/database/production/users/orderly:password
-    MONTAGU_PASSWORD: VAULT:secret/database/production/users/orderly:password
+    MONTAGU_DB_PASSWORD_PRODUCTION: VAULT:secret/database/production/users/readonly:password
     ORDERLY_API_SERVER_IDENTITY: production
     ANNEX_HOST: annex.montagu.dide.ic.ac.uk
     ANNEX_PORT: 15432

--- a/config/science.yml
+++ b/config/science.yml
@@ -12,10 +12,8 @@ orderly:
   ## from the vault, use the format VAULT:<path>:<key>
   env:
     MONTAGU_DB_DEFAULT_INSTANCE: science
-    MONTAGU_DB_PASSWORD_SCIENCE: VAULT:secret/database/science/users/orderly:password
-    MONTAGU_PASSWORD: VAULT:secret/database/science/users/orderly:password
+    MONTAGU_DB_PASSWORD_SCIENCE: VAULT:secret/database/science/users/readonly:password
     ORDERLY_API_SERVER_IDENTITY: science
     ANNEX_HOST: annex.montagu.dide.ic.ac.uk
     ANNEX_PORT: 15432
     ANNEX_PASSWORD: VAULT:secret/annex/users/readonly:password
-

--- a/config/uat.yml
+++ b/config/uat.yml
@@ -13,7 +13,6 @@ orderly:
   env:
     MONTAGU_DB_DEFAULT_INSTANCE: uat
     MONTAGU_DB_PASSWORD_UAT: readonly
-    MONTAGU_PASSWORD: orderly
     ORDERLY_API_SERVER_IDENTITY: uat
     ANNEX_HOST: db_annex
     ANNEX_PORT: 5432


### PR DESCRIPTION
In the current configuration, we fetch the wrong password relative to the username that is now given in [montagu-reports](https://github.com/vimc/montagu-reports/blob/master/orderly_config.yml#L9).  This PR also removes several obsolete environment variables