### PR TITLE
Add production db password to science

### DIFF
--- a/config/science.yml
+++ b/config/science.yml
@@ -17,3 +17,5 @@ orderly:
     ANNEX_HOST: annex.montagu.dide.ic.ac.uk
     ANNEX_PORT: 15432
     ANNEX_PASSWORD: VAULT:secret/annex/users/readonly:password
+    MONTAGU_DB_PASSWORD_PRODUCTION: VAULT:secret/database/production/users/readonly:password
+


### PR DESCRIPTION
I think this is the appropriate place for this fix to go - but basing this off a bit of reading in `orderly-web-deploy`.