### PR TITLE
vimc-4535: Add deploy keys to science and production

### DIFF
--- a/config/production.yml
+++ b/config/production.yml
@@ -15,3 +15,4 @@ orderly:
     ANNEX_HOST: annex.montagu.dide.ic.ac.uk
     ANNEX_PORT: 15432
     ANNEX_PASSWORD: VAULT:secret/annex/users/readonly:password
+    VERSE_DEPLOY_KEY: VAULT:secret/verse/deploy:private

--- a/config/science.yml
+++ b/config/science.yml
@@ -1,4 +1,4 @@
-web:
+:
   image:
     repo: vimc
   ## public url of the web service:
@@ -18,4 +18,4 @@ orderly:
     ANNEX_PORT: 15432
     ANNEX_PASSWORD: VAULT:secret/annex/users/readonly:password
     MONTAGU_DB_PASSWORD_PRODUCTION: VAULT:secret/database/production/users/readonly:password
-
+    VERSE_DEPLOY_KEY: VAULT:secret/verse/deploy:private

--- a/config/science.yml
+++ b/config/science.yml
@@ -1,4 +1,4 @@
-:
+web:
   image:
     repo: vimc
   ## public url of the web service:


### PR DESCRIPTION
This adds an additional secret to the science and production OW instances that we will use in order to get the verse code cloned onto the orderly volume (this happens during running of the report)