### PR TITLE
remove packit config

### DIFF
--- a/config/orderly-web.yml
+++ b/config/orderly-web.yml
@@ -56,18 +56,6 @@ outpack:
     name: outpack_server
     tag: main
 
-packit:
-  repo: mrcide
-  api:
-    name: packit-api
-    tag: main
-  app:
-    name: packit
-    tag: main
-  db:
-    name: packit-db
-    tag: main
-
 ## Redis configuration
 redis:
   image:


### PR DESCRIPTION
This removes packit config from the orderly-web deployment, as the packit deployment is currently broken because the deployment uses the old static sql schema. I've tested this on uat, and removing the config means it doesn't attempt to deploy packit.