### PR TITLE
Drop outpack

### DIFF
--- a/config/orderly-web.yml
+++ b/config/orderly-web.yml
@@ -45,16 +45,6 @@ volumes:
   css: orderly_web_css
   documents: montagu_documents
   redis: orderly_web_redis_data
-  outpack: orderly_web_outpack
-
-outpack:
-  repo: mrcide
-  migrate:
-    name: outpack.orderly
-    tag: main
-  server:
-    name: outpack_server
-    tag: main
 
 ## Redis configuration
 redis:


### PR DESCRIPTION
This PR drops outpack from the orderly web deploy.  The migration will need to be run manually in future.  This is currently running on uat.

Closes #25 